### PR TITLE
Fix build with .NET Core 3 SDK 

### DIFF
--- a/Vostok.Configuration/Vostok.Configuration.csproj
+++ b/Vostok.Configuration/Vostok.Configuration.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\vostok.devtools\library-common-props\Main-Project.props" />
   <Import Project="..\..\vostok.devtools\git-commit-to-assembly-title\Vostok.Tools.GitCommit2AssemblyTitle.props" />
@@ -37,6 +37,10 @@
     <PackageReference Include="System.Reactive.Linq" Version="4.1.2" PrivateAssets="all" />
     <PackageReference Include="SimpleInjector" Version="4.4.3" PrivateAssets="all" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" PrivateAssets="all" />
+    <PackageReference Update="@(PackageReference)">
+      <PrivateAssets>All</PrivateAssets>
+      <Publish Condition=" '%(PackageReference.Publish)' != 'false' ">true</Publish>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Vostok.Configuration.Abstractions">


### PR DESCRIPTION
Возможный вариант фикса билда.
Под .NET Core 3 почему-то перестали появляться зависимости PackageReference есть паблишить для (netstandard?)