### PR TITLE
fixed error `Duplicate type name within an assembly.`

### DIFF
--- a/Vostok.Configuration.Tests/Helpers/DynamicTypeHelper_Tests.cs
+++ b/Vostok.Configuration.Tests/Helpers/DynamicTypeHelper_Tests.cs
@@ -28,6 +28,16 @@ namespace Vostok.Configuration.Tests.Helpers
         }
 
         [Test]
+        public void Helper_should_implement_generic_interface_with_different_types_multiple_times()
+        {
+            var implType1 = DynamicTypesHelper.ImplementType(typeof(IGenericInterface<bool, int>));
+            var implType2 = DynamicTypesHelper.ImplementType(typeof(IGenericInterface<int, bool>));
+
+            implType1.GetInterfaces().Should().Contain(typeof(IGenericInterface<bool, int>));
+            implType2.GetInterfaces().Should().Contain(typeof(IGenericInterface<int, bool>));
+        }
+
+        [Test]
         public void Helper_should_add_attributes_to_type()
         {
             var implType = DynamicTypesHelper.ImplementType(typeof(ICustomInterface));
@@ -64,6 +74,10 @@ namespace Vostok.Configuration.Tests.Helpers
     }
 
     internal interface IInternalInterface
+    {
+    }
+
+    public interface IGenericInterface<T1, T2>
     {
     }
 

--- a/Vostok.Configuration/Helpers/DynamicTypesHelper.cs
+++ b/Vostok.Configuration/Helpers/DynamicTypesHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -80,9 +81,9 @@ namespace Vostok.Configuration.Helpers
         private static TypeBuilder StartType(Type baseType, string suffix)
         {
             var builder = ObtainModuleBuilder(baseType);
-
+            var genericSuffix = GetGenericArgsSuffix(baseType);
             var typeBuilder = builder.DefineType(
-                $"{baseType.Namespace}.{baseType.Name}<{suffix}>",
+                $"{baseType.Namespace}.{baseType.Name}<{suffix}>{genericSuffix}",
                 DefaultTypeAttributes,
                 baseType.IsInterface ? null : baseType,
                 baseType.IsInterface ? new[] {baseType} : Type.EmptyTypes);
@@ -91,6 +92,16 @@ namespace Vostok.Configuration.Helpers
                 typeBuilder.SetCustomAttribute(CreateCustomAttributeBuilder(attribute));
 
             return typeBuilder;
+        }
+
+        private static string GetGenericArgsSuffix(Type baseType)
+        {
+            if (!baseType.IsGenericType)
+                return string.Empty;
+
+            IStructuralEquatable genericArguments = baseType.GetGenericArguments();
+            var hashCode = genericArguments.GetHashCode(EqualityComparer<Type>.Default);
+            return $"<Generics{hashCode}>";
         }
 
         private static CustomAttributeBuilder CreateCustomAttributeBuilder(CustomAttributeData attribute)


### PR DESCRIPTION
 when DynamicTypesHelper tries implement the same interfaces with different generic arguments