### PR TITLE
Implemented IComparable for DataSize

### DIFF
--- a/Vostok.Configuration.Tests/Primitives/DataRate_Tests.cs
+++ b/Vostok.Configuration.Tests/Primitives/DataRate_Tests.cs
@@ -162,6 +162,21 @@ namespace Vostok.Configuration.Tests.Primitives
             new DataRate(val1).CompareTo(new DataRate(val2)).Should().Be(res);
         }
 
+        [Test]
+        public void CompareTo_object_should_work_correctly()
+        {
+            var val1 = new DataRate(10);
+            var val2 = (object)null;
+            var val3 = new object();
+            var val4 = (DataRate?)new DataRate(100);
+            var val5 = (DataRate?)null;
+
+            val1.CompareTo(val2).Should().Be(1);
+            val1.CompareTo(val3).Should().Be(1);
+            val1.CompareTo(val4).Should().Be(-1);
+            val1.CompareTo(val5).Should().Be(1);
+        }
+
         [TestCase(10, 10, true)]
         [TestCase(10, 20, false)]
         public void Equals_should_work_correctly(int val1, int val2, bool res)

--- a/Vostok.Configuration.Tests/Primitives/DataSize_Tests.cs
+++ b/Vostok.Configuration.Tests/Primitives/DataSize_Tests.cs
@@ -204,6 +204,21 @@ namespace Vostok.Configuration.Tests.Primitives
             new DataSize(val1).CompareTo(new DataSize(val2)).Should().Be(res);
         }
 
+        [Test]
+        public void CompareTo_object_should_work_correctly()
+        {
+            var val1 = new DataSize(10);
+            var val2 = (object)null;
+            var val3 = new object();
+            var val4 = (DataSize?)new DataSize(100);
+            var val5 = (DataSize?)null;
+
+            val1.CompareTo(val2).Should().Be(1);
+            val1.CompareTo(val3).Should().Be(1);
+            val1.CompareTo(val4).Should().Be(-1);
+            val1.CompareTo(val5).Should().Be(1);
+        }
+
         [TestCase(10, 10, true)]
         [TestCase(10, 20, false)]
         public void Equals_should_work_correctly(int val1, int val2, bool res)

--- a/Vostok.Configuration/Primitives/DataRate.cs
+++ b/Vostok.Configuration/Primitives/DataRate.cs
@@ -9,7 +9,7 @@ namespace Vostok.Configuration.Primitives
     /// </summary>
     [PublicAPI]
     [Serializable]
-    public struct DataRate : IEquatable<DataRate>, IComparable<DataRate>
+    public struct DataRate : IEquatable<DataRate>, IComparable<DataRate>, IComparable
     {
         /// <summary>
         /// Creates a new instance of <see cref="DataRate"/> class.
@@ -173,6 +173,10 @@ namespace Vostok.Configuration.Primitives
         /// <inheritdoc />
         public int CompareTo(DataRate other) =>
             BytesPerSecond.CompareTo(other.BytesPerSecond);
+
+        /// <inheritdoc />
+        public int CompareTo(object obj) =>
+            obj is DataRate dataRate ? CompareTo(dataRate) : 1;
 
         #endregion
     }

--- a/Vostok.Configuration/Primitives/DataSize.cs
+++ b/Vostok.Configuration/Primitives/DataSize.cs
@@ -9,7 +9,7 @@ namespace Vostok.Configuration.Primitives
     /// </summary>
     [PublicAPI]
     [Serializable]
-    public struct DataSize : IEquatable<DataSize>, IComparable<DataSize>
+    public struct DataSize : IEquatable<DataSize>, IComparable<DataSize>, IComparable
     {
         /// <summary>
         /// Creates a new instance of <see cref="DataSize"/> class.
@@ -187,6 +187,10 @@ namespace Vostok.Configuration.Primitives
         /// <inheritdoc />
         public int CompareTo(DataSize other) =>
             Bytes.CompareTo(other.Bytes);
+
+        /// <inheritdoc />
+        public int CompareTo(object obj) =>
+            obj is DataSize dataSize ? CompareTo(dataSize) : 1;
 
         public static bool operator>(DataSize size1, DataSize size2) =>
             size1.Bytes > size2.Bytes;

--- a/Vostok.Configuration/PublicAPI.Shipped.txt
+++ b/Vostok.Configuration/PublicAPI.Shipped.txt
@@ -194,6 +194,7 @@ Vostok.Configuration.Primitives.DataRateConversionExtensions
 Vostok.Configuration.Primitives.DataSize
 Vostok.Configuration.Primitives.DataSize.Bytes.get -> long
 Vostok.Configuration.Primitives.DataSize.CompareTo(Vostok.Configuration.Primitives.DataSize other) -> int
+Vostok.Configuration.Primitives.DataSize.CompareTo(object obj) -> int
 Vostok.Configuration.Primitives.DataSize.DataSize() -> void
 Vostok.Configuration.Primitives.DataSize.DataSize(long bytes) -> void
 Vostok.Configuration.Primitives.DataSize.Equals(Vostok.Configuration.Primitives.DataSize other) -> bool

--- a/Vostok.Configuration/PublicAPI.Shipped.txt
+++ b/Vostok.Configuration/PublicAPI.Shipped.txt
@@ -181,6 +181,7 @@ Vostok.Configuration.Parsers.TryParse<T>
 Vostok.Configuration.Primitives.DataRate
 Vostok.Configuration.Primitives.DataRate.BytesPerSecond.get -> long
 Vostok.Configuration.Primitives.DataRate.CompareTo(Vostok.Configuration.Primitives.DataRate other) -> int
+Vostok.Configuration.Primitives.DataRate.CompareTo(object obj) -> int
 Vostok.Configuration.Primitives.DataRate.DataRate() -> void
 Vostok.Configuration.Primitives.DataRate.DataRate(long bytesPerSecond) -> void
 Vostok.Configuration.Primitives.DataRate.Equals(Vostok.Configuration.Primitives.DataRate other) -> bool


### PR DESCRIPTION
Some APIs may require both IComparable<T>, IComparable implemented. For example FluentValidation:
![image](https://user-images.githubusercontent.com/11368664/203641012-7a93badc-9427-416d-929d-87aec6c10664.png)
![image](https://user-images.githubusercontent.com/11368664/203641200-0b6d714e-28e1-4620-9f52-9dba13c75e71.png)
